### PR TITLE
Mars-cli update 功能

### DIFF
--- a/packages/mars-cli/README.md
+++ b/packages/mars-cli/README.md
@@ -2,13 +2,13 @@
 
 ## 安装
 
-``` sh
+```shell
 npm i -g @marsjs-cli
 ```
 
 ## 创建项目
 
-``` sh
+```shell
 mars create my-project
 ```
 
@@ -16,7 +16,7 @@ mars create my-project
 
 ## 开发项目
 
-``` sh
+```shell
 mars serve
 ```
 
@@ -24,8 +24,24 @@ mars serve
 
 ## 构建项目（用于上线）
 
-``` sh
+```shell
 mars build
 ```
 
 可通过 `-t` 设置编译目标，可选值为 `swan` | `wx` | `h5`，默认 `swan`；
+
+## 升级当前项目 Mars 相关依赖库
+
+```shell
+mars update
+```
+
+相当于 `npm update`。
+
+可指定 `-f` 来升级到最新版本，
+
+```shell
+mars update -f
+```
+
+相当于 `npm install xxx@latest`。

--- a/packages/mars-cli/bin/mars.js
+++ b/packages/mars-cli/bin/mars.js
@@ -178,6 +178,22 @@ program
         start(options);
     });
 
+program
+    .command('update')
+    .description('update all mars dependences')
+    .option('-r, --registry <url>', 'Use specified npm registry when installing dependencies (only for npm)')
+    .option('-f, --force', 'Force update all denpenences to latest version')
+    .action(cmd => {
+        const update = require('../lib/update');
+        const options = cleanArgs(cmd);
+
+        if (!options.registry) {
+            options.registry = defaultConfig.registry;
+        }
+
+        update(options);
+    });
+
 // output help information on unknown commands
 program
     .arguments('<command>')

--- a/packages/mars-cli/docs/workflow.md
+++ b/packages/mars-cli/docs/workflow.md
@@ -15,25 +15,20 @@ await create(name, options);
 
 执行 create 命令时，提示用户选择创建的项目是否需要支持 h5，之后修改 preset，将参数传给 @marsjs/cli-template。@marsjs/cli-template 会根据参数 render 不同的文件内容。
 
-- mars-cli-template/generator/template: 不支持 h5 的项目文件
-- mars-cli-template/generator/template-h5: 不支持 h5 的项目文件
+- mars-cli-template/generator/template: 基础项目文件，无论是否支持 H5，都会使用
+- mars-cli-template/generator/template-h5: 当项目需要支持 h5 时，会在 template 的基础上增加 template-h5 的内容
 
-> TODO: 将支持 h5 的项目模板和不支持 h5 的项目模板进行合并，抽取公共内容。
-
-除此之外，还有一个 dist-h5 文件夹，这个文件夹为产出 vue 工程所需要的一些文件，不是通过 vue-cli 的 generator 进行 render 的，是直接进行了文件拷贝。拷贝发生在每次执行 h5 编译时，判断文件不存在才会拷贝。
+除此之外，还有一个 dist-h5 文件夹，这个文件夹为产出 vue 工程所需要的一些文件，不需通过 vue-cli 的 generator 进行 render，直接进行文件拷贝。拷贝发生在每次执行 h5 编译时，判断文件不存在时进行拷贝。
 
 ### npm 脚本
 
 产出的项目中，默认在 package.json 中提供了到多端的 build 和 serve 脚本。
 
-另外如果是支持 h5 的项目，还有一个 build-dist-h5 脚本，这个脚本用于在 mars 编译产出 vue 工程后，使用 vue-cli-service 对 vue 工程进行编译，一般不需要执行。
-
-至于为什么会需要使用 vue-cli-service 对 vue 工程进行编译，见下方 build 指令。
-
+另外如果是支持 h5 的项目，还有一个 build-dist-h5 脚本，这个脚本用于在 mars 编译产出 vue 工程后，使用 vue-cli-service 对 vue 工程进行编译，一般不需要单独执行。
 
 ## build、serve 指令
 
-build 和 serve 指令的执行流程基本相同，使用的是 mars-cli/lib/script/runjs 中的脚本，内部使用 gulp 对小程序进行编译。
+build 和 serve 指令的执行流程基本相同，使用的是 @marsjs/build/src/script/runjs 中的脚本，内部使用 gulp 对小程序进行编译。
 
 ### h5 的编译
 
@@ -41,4 +36,6 @@ build 和 serve 指令的执行流程基本相同，使用的是 mars-cli/lib/sc
 
 
 ## mars-cli-service
+
+mars-cli-service 实际引用了 @vue/cli-service/lib/Service，对小程序转换出的 vue 项目进行编译。
 

--- a/packages/mars-cli/lib/update.js
+++ b/packages/mars-cli/lib/update.js
@@ -1,0 +1,91 @@
+/**
+ * @file 升级依赖
+ * @author meixuguang
+ */
+
+const {error, stopSpinner} = require('@vue/cli-shared-utils');
+const execa = require('execa');
+const fs = require('fs-extra');
+
+function executeCommand(command, args, targetDir) {
+    return new Promise((resolve, reject) => {
+
+        const child = execa(command, args, {
+            cwd: targetDir,
+            stdio: ['inherit', 'inherit', 'inherit']
+        });
+
+        child.on('close', code => {
+            if (code !== 0) {
+                reject(`command failed: ${command} ${args.join(' ')}`);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
+const dependencyList = [
+    '@marsjs/build',
+    '@marsjs/core'
+];
+const dependencyListH5 = [
+    '@marsjs/components',
+    '@marsjs/api',
+    'atom-web-compiler',
+    'atom2vue-loader',
+    '@marsjs/vue-cli-plugin-mars-web'
+];
+
+function getDependencyList() {
+    if (fs.existsSync(process.cwd() + '/vue.config.js')) {
+        return [...dependencyList, ...dependencyListH5];
+    }
+    return dependencyList;
+}
+
+async function update(cmd) {
+    if (cmd.force) {
+        forceUpdate(cmd.registry);
+    }
+    else {
+        compatibleUpdate(cmd.registry);
+    }
+}
+
+async function compatibleUpdate(registry) {
+    const dep = getDependencyList();
+    const args = [
+        'update',
+        ...dep,
+        `--registry=${registry}`
+    ];
+
+    return executeCommand('npm', args, process.cwd());
+}
+
+async function forceUpdate(registry) {
+    const args = [
+        'install'
+    ];
+    const dep = getDependencyList();
+
+    for (let i = 0; i < dep.length; i++) {
+        const id = dep[i];
+        args.push(`${id}@latest`);
+    }
+    args.push(`--registry=${registry}`);
+
+    return executeCommand('npm', args, process.cwd());
+}
+
+
+
+module.exports = (...args) =>
+    update(...args).catch(err => {
+        stopSpinner(false); // do not persist
+        error(err);
+        if (!process.env.VUE_CLI_TEST) {
+            process.exit(1);
+        }
+    });


### PR DESCRIPTION
## 升级当前项目 Mars 相关依赖库

```shell
mars update
```

相当于 `npm update`。

可指定 `-f` 来升级到最新版本，

```shell
mars update -f
```

相当于 `npm install xxx@latest`。