### PR TITLE
fix: preprocessors merge 错误，不能设置 options

### DIFF
--- a/docs/guide/start.md
+++ b/docs/guide/start.md
@@ -88,7 +88,7 @@ options 配置请参考 [postcss-px2units](https://www.npmjs.com/package/postcss
 #### `preprocessors`
 Type: `{[name: string]: processor}`
 
-Type of `processor`: `extnames: Array<lang> | config`
+Type of `processor`: `extnames: config`
 
 Type of `config`: `{ extnames: Array<lang> [, options: Object, process: process | void]}`
 
@@ -132,10 +132,18 @@ module.exports = function (target) {
             }
         },
         preprocessors: {
-            less: ['less'],
-            sass: ['sass', 'scss'],
-            stylus: ['stylus', 'styl'],
-            typescript: ['ts']
+            less: {
+                extnames: ['less']
+            },
+            sass: {
+                extnames: ['sass', 'scss']
+            },
+            stylus: {
+                extnames: ['stylus', 'styl']
+            },
+            typescript: {
+                extnames: ['ts']
+            }
         },
         postprocessors: {
             postcss: {

--- a/packages/mars-build/src/scripts/defaultConfig.js
+++ b/packages/mars-build/src/scripts/defaultConfig.js
@@ -21,10 +21,18 @@ module.exports = function (merge, target) {
             }
         },
         preprocessors: {
-            less: ['less'],
-            sass: ['sass', 'scss'],
-            stylus: ['stylus', 'styl'],
-            typescript: ['ts']
+            less: {
+                extnames: ['less']
+            },
+            sass: {
+                extnames: ['sass', 'scss']
+            },
+            stylus: {
+                extnames: ['stylus', 'styl']
+            },
+            typescript: {
+                extnames: ['ts']
+            }
         },
         postprocessors: {
             postcss: {


### PR DESCRIPTION
preprocessors 默认设置为数组：

```javascript
preprocessors: {
    less: ['less'],
    sass: ['sass', 'scss'],
    stylus: ['stylus', 'styl'],
    typescript: ['ts']
}
```

如果在 mars.config.js 中设置

```javascript
preprocessors: {
    stylus: {
        extnames: ['stylus'],
        options: {
            'import': [path.resolve(__dirname, './src/lib/stylus/mixins.styl')]
        }
    }
},
```

script/run.js 中会使用 lodash 的 merge 方法进行选项合并，得到的结果依旧为数组，使得 options 不生效。

暂时将默认选项修改，后续再考虑支持数组形式。