### PR TITLE
feat: make H5 compatible with mp comp and pages

### DIFF
--- a/packages/mars-build/src/compiler/script/babel-plugin-script.js
+++ b/packages/mars-build/src/compiler/script/babel-plugin-script.js
@@ -51,6 +51,19 @@ const getPropertyVisitor = (t, options) => {
 
             if (propName === 'config') {
                 const configValue = getPlainObjectNodeValue(path.node.value, path, t) || {};
+
+                if (options.isApp) {
+                    if (configValue.pages) {
+                        configValue.pages = configValue.pages.map(item => item.replace(/\.(swan|mp)$/, ''));
+                    }
+                    if (configValue.tabBar && configValue.tabBar.list) {
+                        configValue.tabBar.list = configValue.tabBar.list.map(item => {
+                            item.pagePath = item.pagePath.replace(/\.(swan|mp)$/, '');
+                            return item;
+                        });
+                    }
+                }
+
                 options.file && (options.file.config = configValue);
                 path.remove();
             }

--- a/packages/mars-build/src/h5/transform/plugins/transformScriptPlugin.js
+++ b/packages/mars-build/src/h5/transform/plugins/transformScriptPlugin.js
@@ -131,6 +131,13 @@ const Property = (t, options) => {
 
             if (path.node.key.name === 'config') {
                 const configValue = getPlainObjectNodeValue(path.node.value, path, t) || {};
+
+                if (configValue.pages) {
+                    configValue.pages = configValue.pages.filter(item => !/\.(swan|mp)$/.test(item));
+                }
+                if (configValue.tabBar && configValue.tabBar.list) {
+                    configValue.tabBar.list = configValue.tabBar.list.filter(item => !/\.(swan|mp)$/.test(item.pagePath));
+                }
                 options.baseOptions && (options.baseOptions.config = configValue);
                 path.remove();
             }

--- a/packages/mars-build/src/scripts/defaultConfig.js
+++ b/packages/mars-build/src/scripts/defaultConfig.js
@@ -8,7 +8,10 @@ module.exports = function (target) {
         projectFiles: ['project.swan.json', 'project.config.json'],
         source: ['src/**/*.vue'],
         dest: target === 'h5' ? './dist-h5/src' : `./dist-${target}`,
-        assets: [
+        assets: target === 'h5' ? [
+            'src/**/*.!(vue|swan|wxml)'
+        ]
+        : [
             'src/**/*.!(vue)'
         ],
         designWidth: 750,


### PR DESCRIPTION
- 使用小程序组件

    方法不变，h5 中会忽略，目前 template 中不会移除该组件。

- 使用小程序页面

    需要加 .swan 后缀，h5 中会忽略掉。