### PR TITLE
feat: support setting H5 title

### DIFF
--- a/packages/mars-cli-template/generator/dist-h5/public/index.html
+++ b/packages/mars-cli-template/generator/dist-h5/public/index.html
@@ -1,16 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+
+<head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>dist-h5</title>
-  </head>
-  <body>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+</head>
+
+<body>
     <noscript>
-      <strong>We're sorry but dist-h5 doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+        <strong>We're sorry but dist-h5 doesn't work properly without JavaScript enabled. Please enable it to
+            continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
-  </body>
+</body>
+
 </html>

--- a/packages/mars-cli-template/generator/template-h5/mars/vue.config.js
+++ b/packages/mars-cli-template/generator/template-h5/mars/vue.config.js
@@ -7,5 +7,13 @@ module.exports = {
         '@marsjs/api',
         '@marsjs/components'
     ],
-    parallel: false
+    parallel: false,
+    chainWebpack: config => {
+        config
+            .plugin('html')
+            .tap(args => {
+                args[0].title = 'Mars demo';
+                return args;
+            });
+    }
 };


### PR DESCRIPTION
支持修改生成 h5 页面的 title，直接在 vue.config.js 中进行设置