### PR TITLE
fix: mars serve error

### DIFF
--- a/packages/mars-build/src/compiler/file/compileModules.js
+++ b/packages/mars-build/src/compiler/file/compileModules.js
@@ -69,6 +69,7 @@ function compile(val, key, destPath) {
                 filename: modulePath,
                 libraryTarget: 'commonjs'
             },
+            devtool: false,
             mode: process.env.NODE_ENV === 'production' ? 'production' : 'development'
         }, (err, stats) => {
             if (err) {

--- a/packages/mars-build/src/compiler/runtime/compiler.js
+++ b/packages/mars-build/src/compiler/runtime/compiler.js
@@ -46,6 +46,7 @@ function compile(options) {
                 filename: 'index.js',
                 libraryTarget: 'commonjs'
             },
+            devtool: false,
             mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
             plugins: [
                 new webpack.DefinePlugin({


### PR DESCRIPTION
fix: process.env.NODE_ENV 为 development 时，webpack 会使用 eval()，在小程序中报错。