### PR TITLE
fix: '||' is marked as filter

### DIFF
--- a/packages/mars-build/src/compiler/template/mark-component.js
+++ b/packages/mars-build/src/compiler/template/mark-component.js
@@ -89,7 +89,7 @@ function isComplexExp(exp) {
 function getFilters(node) {
     let props = node.attrsList
         ? node.attrsList.filter(({name, value}) =>
-            name.indexOf(':') >= 0 && (value.indexOf('|') > 0 || isComplexExp(value))
+            name.indexOf(':') >= 0 && (/[^|]+\|[^|]+/.test(value) || isComplexExp(value))
         )
         : [];
     props = props.map(({name}) => name.replace(/^(v-bind)?:/, ''));


### PR DESCRIPTION
```html
<view v-show="isSelectAll || selectIndexArr[index]"/>
```

v-show 中的内容被识别为 filter 了