### PR TITLE
H5 平台路由文件生成时，框架解析错误

### DIFF
--- a/packages/mars-build/src/h5/transform/plugins/transformRouterPlugin.js
+++ b/packages/mars-build/src/h5/transform/plugins/transformRouterPlugin.js
@@ -8,7 +8,7 @@
 
 // page/home/index to PageHomeIndex
 function toCamel(name) {
-    let camelName = name.replace(/^\//, '').replace(/\/(\w)(\w+)/g, (a, b, c) => b.toUpperCase() + c.toLowerCase());
+    let camelName = name.replace(/^\//, '').replace(/[\/|-](\w)(\w+)/g, (a, b, c) => b.toUpperCase() + c.toLowerCase());
     return camelName.substring(0, 1).toUpperCase() + camelName.substring(1);
 }
 


### PR DESCRIPTION
例如 `pages/ui/layout/scroll-view` 会被转化成 `import PagesUiLayoutScroll-view from "./pages/ui/layout/scroll-view.vue";`，需要需要将 kebab-case命名转成大驼峰命名。