### PR TITLE
feat: 引入 sfc 组件时，支持 xxx.vue 写法

### DIFF
--- a/packages/mars-build/src/compiler/script/babel-plugin-script.js
+++ b/packages/mars-build/src/compiler/script/babel-plugin-script.js
@@ -101,7 +101,7 @@ const getPropertyVisitor = (t, options) => {
                             const bindNode = bindPath.node;
 
                             if (t.isImportDeclaration(bindParentNode)) {
-                                const bindVaule = bindParentNode.source.value + '.vue';
+                                const bindVaule = bindParentNode.source.value.replace(/\.vue$/, '') + '.vue';
                                 components[keyName] = bindVaule;
                                 bindParentNode.source = t.stringLiteral(bindVaule);
                             }
@@ -112,7 +112,7 @@ const getPropertyVisitor = (t, options) => {
                                 && bindNode.init.callee.name === 'require'
                                 && t.isStringLiteral(bindNode.init.arguments[0])
                             ) {
-                                const bindVaule = bindNode.init.arguments[0].value + '.vue';
+                                const bindVaule = bindNode.init.arguments[0].value.replace(/\.vue$/, '') + '.vue';
                                 components[keyName] = bindVaule;
                                 bindNode.init.arguments[0] = t.stringLiteral(bindVaule);
                             }


### PR DESCRIPTION
使用 Vetur 插件时，不能省略 .vue 否则会报错
但写上 .vue 时，Mars 编译会生成 xxx.vue.vue ，运行报错
https://github.com/vuejs/vetur/blob/master/docs/FAQ.md#vetur-cannot-recognize-my-vue-component-import-such-as-import-comp-from-comp